### PR TITLE
ESPHome 2026.4.1: `little-endian` byte order for images

### DIFF
--- a/components/matrix_lamp/__init__.py
+++ b/components/matrix_lamp/__init__.py
@@ -300,8 +300,8 @@ async def to_code(config) -> None:  # noqa: ANN001 C901 PLR0912 PLR0915
                     dither,
                     invert_alpha,
                 )
-                if hasattr(encoder, "set_big_endian"):
-                    encoder.set_big_endian(True)
+                encoder.set_big_endian(False)
+
                 for frame_index in range(frame_count):
                     image.seek(frame_index)
                     pixels = encoder.convert(image.resize((width, height)), path).getdata()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

ESPHome 2026.4.1: `little-endian` byte order for images

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] The code has been formatted using YamlLint / Ruff

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated

<!--
  Thank you for contributing <3
-->
